### PR TITLE
[FEAT] 주문 수정, 상태변경, 삭제 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
@@ -48,7 +49,15 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	implementation 'com.followMe:common-lib:1.0.1'
+	implementation 'com.followMe:common-lib:1.0.2'
+
+	implementation "io.github.openfeign.querydsl:querydsl-core:7.1"
+	implementation "io.github.openfeign.querydsl:querydsl-jpa:7.1"
+
+	annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.1:jakarta"
+
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 dependencyManagement {
@@ -65,5 +74,6 @@ spotless {
 	java {
 		googleJavaFormat('1.24.0')
 		target 'src/**/*.java'
+		targetExclude 'src/main/generated/**/*.java' // ← Q클래스 제외
 	}
 }

--- a/docs/order.http
+++ b/docs/order.http
@@ -1,14 +1,51 @@
+@baseUrl = http://localhost:8082
+@userId = 11111111-1111-1111-1111-111111111111
+@vendorId = bbbbbbbb-0000-0000-0000-000000000001
+@hubId = 33333333-3333-3333-3333-333333333333
+@orderId = aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+
 ### 주문 생성
-POST http://localhost:8082/api/v1/order
+
+POST {{baseUrl}}/api/v1/orders
 Content-Type: application/json
+X-User-Id: {{userId}}
+X-User-Role: MASTER
+X-Hub-Id: {{hubId}}
+X-Vendor-Id: {{vendorId}}
 
 {
   "productId": "aaaaaaaa-0000-0000-0000-000000000001",
   "productName": "축구공",
   "requestVendorId": "bbbbbbbb-0000-0000-0000-000000000001",
   "requestVendorName": "요청업체A",
+  "requestVendorHubId": "dddddddd-0000-0000-0000-000000000001",
   "receiverVendorId": "cccccccc-0000-0000-0000-000000000001",
   "receiverVendorName": "수령업체B",
+  "receiverVendorHubId": "eeeeeeee-0000-0000-0000-000000000001",
   "quantity": 10,
   "requestNote": "빠른 배송 부탁드립니다"
 }
+
+### 단건 조회
+
+GET {{baseUrl}}/api/v1/orders/6a9ac0ef-7c43-4cb2-bec2-23fdf49ed3d9
+X-User-Id: {{userId}}
+X-User-Role: MASTER
+X-Hub-Id: {{hubId}}
+X-Vendor-Id: {{vendorId}}
+
+### 커서 조회 기본
+
+GET {{baseUrl}}/api/v1/orders?cursor=null&size=10
+X-User-Id: {{userId}}
+X-User-Role: MASTER
+X-Hub-Id: {{hubId}}
+X-Vendor-Id: {{vendorId}}
+
+### 커서 + 조건 조회
+
+GET {{baseUrl}}/api/v1/orders?cursor=2024-01-01T00:00:00&size=10&requestVendorId={{vendorId}}&status=CREATED
+X-User-Id: {{userId}}
+X-User-Role: MASTER
+X-Hub-Id: {{hubId}}
+X-Vendor-Id: {{vendorId}}

--- a/src/main/java/com/followMe/order_server/order/application/OrderSearchFilter.java
+++ b/src/main/java/com/followMe/order_server/order/application/OrderSearchFilter.java
@@ -1,0 +1,43 @@
+package com.followMe.order_server.order.application;
+
+import com.followMe.order_server.order.application.dto.request.OrderSearchCondition;
+import com.followMe.order_server.order.application.dto.request.UserContext;
+import com.followMe.order_server.order.application.dto.request.UserRole;
+import java.util.UUID;
+
+public class OrderSearchFilter {
+
+  public static OrderSearchCondition applyRoleFilter(
+      OrderSearchCondition condition, UserContext userContext) {
+    UserRole role = userContext.userRole();
+
+    return switch (role) {
+      case VENDOR -> {
+        UUID vendorId = userContext.vendorId();
+        yield new OrderSearchCondition(
+            null,
+            condition.productId(),
+            condition.orderId(),
+            condition.productName(),
+            condition.startDateTime(),
+            condition.endDateTime(),
+            condition.createdBy(),
+            vendorId,
+            condition.status());
+      }
+      case DELIVERY_MANAGER -> condition;
+      case HUB_MANAGER ->
+          new OrderSearchCondition(
+              userContext.hubId(),
+              condition.productId(),
+              condition.orderId(),
+              condition.productName(),
+              condition.startDateTime(),
+              condition.endDateTime(),
+              condition.createdBy(),
+              condition.vendorId(),
+              condition.status());
+      case MASTER -> condition;
+    };
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/application/OrderService.java
+++ b/src/main/java/com/followMe/order_server/order/application/OrderService.java
@@ -1,6 +1,10 @@
 package com.followMe.order_server.order.application;
 
+import com.followMe.common.pagination.CursorRequest;
+import com.followMe.common.pagination.CursorResponse;
 import com.followMe.order_server.order.application.dto.request.OrderCreateRequest;
+import com.followMe.order_server.order.application.dto.request.OrderSearchCondition;
+import com.followMe.order_server.order.application.dto.request.UserContext;
 import com.followMe.order_server.order.application.dto.response.OrderResponse;
 import java.util.UUID;
 
@@ -8,4 +12,7 @@ public interface OrderService {
   void create(OrderCreateRequest createRequest);
 
   OrderResponse readById(UUID orderId);
+
+  CursorResponse<OrderResponse> search(
+      CursorRequest cursorRequest, OrderSearchCondition condition, UserContext userContext);
 }

--- a/src/main/java/com/followMe/order_server/order/application/OrderService.java
+++ b/src/main/java/com/followMe/order_server/order/application/OrderService.java
@@ -4,6 +4,8 @@ import com.followMe.common.pagination.CursorRequest;
 import com.followMe.common.pagination.CursorResponse;
 import com.followMe.order_server.order.application.dto.request.OrderCreateRequest;
 import com.followMe.order_server.order.application.dto.request.OrderSearchCondition;
+import com.followMe.order_server.order.application.dto.request.OrderUpdateRequest;
+import com.followMe.order_server.order.application.dto.request.OrderUpdateStateRequest;
 import com.followMe.order_server.order.application.dto.request.UserContext;
 import com.followMe.order_server.order.application.dto.response.OrderResponse;
 import java.util.UUID;
@@ -15,4 +17,10 @@ public interface OrderService {
 
   CursorResponse<OrderResponse> search(
       CursorRequest cursorRequest, OrderSearchCondition condition, UserContext userContext);
+
+  void update(UUID orderId, OrderUpdateRequest updateRequest);
+
+  void updateStatus(UUID orderId, OrderUpdateStateRequest updateStateRequest);
+
+  void softDeleteById(UUID orderId);
 }

--- a/src/main/java/com/followMe/order_server/order/application/OrderService.java
+++ b/src/main/java/com/followMe/order_server/order/application/OrderService.java
@@ -1,7 +1,11 @@
 package com.followMe.order_server.order.application;
 
 import com.followMe.order_server.order.application.dto.request.OrderCreateRequest;
+import com.followMe.order_server.order.application.dto.response.OrderResponse;
+import java.util.UUID;
 
 public interface OrderService {
   void create(OrderCreateRequest createRequest);
+
+  OrderResponse readById(UUID orderId);
 }

--- a/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
+++ b/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
@@ -1,6 +1,7 @@
 package com.followMe.order_server.order.application;
 
 import com.followMe.order_server.order.application.dto.request.OrderCreateRequest;
+import com.followMe.order_server.order.application.dto.response.OrderResponse;
 import com.followMe.order_server.order.domain.Order;
 import com.followMe.order_server.order.domain.ProductInfo;
 import com.followMe.order_server.order.domain.VendorInfo;
@@ -46,5 +47,11 @@ public class OrderServiceImpl implements OrderService {
             request.requestNote());
 
     orderRepository.save(order);
+  }
+
+  @Override
+  public OrderResponse readById(UUID orderId) {
+    Order order = orderRepository.findById(orderId);
+    return OrderResponse.from(order);
   }
 }

--- a/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
+++ b/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
@@ -77,7 +77,6 @@ public class OrderServiceImpl implements OrderService {
         orders,
         cursorRequest.getSize(),
         OrderResponse::from,
-        order -> order.getOrderId().toString()
-        );
+        order -> order.getOrderId().toString());
   }
 }

--- a/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
+++ b/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
@@ -1,6 +1,10 @@
 package com.followMe.order_server.order.application;
 
+import com.followMe.common.pagination.CursorRequest;
+import com.followMe.common.pagination.CursorResponse;
 import com.followMe.order_server.order.application.dto.request.OrderCreateRequest;
+import com.followMe.order_server.order.application.dto.request.OrderSearchCondition;
+import com.followMe.order_server.order.application.dto.request.UserContext;
 import com.followMe.order_server.order.application.dto.response.OrderResponse;
 import com.followMe.order_server.order.domain.Order;
 import com.followMe.order_server.order.domain.ProductInfo;
@@ -8,6 +12,7 @@ import com.followMe.order_server.order.domain.VendorInfo;
 import com.followMe.order_server.order.domain.repository.OrderRepository;
 import com.followMe.order_server.order.infrastructure.client.delivery.DeliveryClientAdapter;
 import com.followMe.order_server.order.infrastructure.client.hub.HubClient;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,18 +34,23 @@ public class OrderServiceImpl implements OrderService {
         new ProductInfo(request.productId(), request.productName(), request.quantity());
 
     VendorInfo requestVendor =
-        new VendorInfo(request.requestVendorId(), request.requestVendorName());
+        new VendorInfo(
+            request.requestVendorId(), request.requestVendorName(), request.requestVendorHubId());
 
     VendorInfo receiverVendor =
-        new VendorInfo(request.receiverVendorId(), request.receiverVendorName());
+        new VendorInfo(
+            request.receiverVendorId(),
+            request.receiverVendorName(),
+            request.receiverVendorHubId());
 
     //    hubClient.getStockBySomething(); // TODO : 재고 확인에 따른 배송 가능 여부 파악
     UUID orderId = UUID.randomUUID();
     Order order =
         Order.ofCreate(
             orderId,
-            deliveryClientAdapter.createDelivery(
-                orderId, request.requestVendorId(), request.receiverVendorId()),
+            //            deliveryClientAdapter.createDelivery(
+            //                orderId, request.requestVendorId(), request.receiverVendorId()),
+            UUID.randomUUID(),
             productInfo,
             requestVendor,
             receiverVendor,
@@ -53,5 +63,25 @@ public class OrderServiceImpl implements OrderService {
   public OrderResponse readById(UUID orderId) {
     Order order = orderRepository.findById(orderId);
     return OrderResponse.from(order);
+  }
+
+  public CursorResponse<OrderResponse> search(
+      CursorRequest cursorRequest, OrderSearchCondition condition, UserContext userContext) {
+    // 권한 기반 조건 고정
+    OrderSearchCondition filteredCondition =
+        OrderSearchFilter.applyRoleFilter(condition, userContext);
+
+    // Repository 호출
+    List<Order> orders =
+        orderRepository.searchByCursor(
+            cursorRequest.getCursor(), cursorRequest.getSize(), filteredCondition);
+
+    // DTO 변환 및 CursorResponse 생성
+    return CursorResponse.of(
+        orders, // List<Order>
+        cursorRequest.getSize(),
+        OrderResponse::from, // mapper
+        order -> order.getOrderId().toString() // cursorExtractor
+        );
   }
 }

--- a/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
+++ b/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
@@ -48,9 +48,8 @@ public class OrderServiceImpl implements OrderService {
     Order order =
         Order.ofCreate(
             orderId,
-            //            deliveryClientAdapter.createDelivery(
-            //                orderId, request.requestVendorId(), request.receiverVendorId()),
-            UUID.randomUUID(),
+            deliveryClientAdapter.createDelivery(
+                orderId, request.requestVendorId(), request.receiverVendorId()),
             productInfo,
             requestVendor,
             receiverVendor,
@@ -67,21 +66,18 @@ public class OrderServiceImpl implements OrderService {
 
   public CursorResponse<OrderResponse> search(
       CursorRequest cursorRequest, OrderSearchCondition condition, UserContext userContext) {
-    // 권한 기반 조건 고정
     OrderSearchCondition filteredCondition =
         OrderSearchFilter.applyRoleFilter(condition, userContext);
 
-    // Repository 호출
     List<Order> orders =
         orderRepository.searchByCursor(
             cursorRequest.getCursor(), cursorRequest.getSize(), filteredCondition);
 
-    // DTO 변환 및 CursorResponse 생성
     return CursorResponse.of(
-        orders, // List<Order>
+        orders,
         cursorRequest.getSize(),
-        OrderResponse::from, // mapper
-        order -> order.getOrderId().toString() // cursorExtractor
+        OrderResponse::from,
+        order -> order.getOrderId().toString()
         );
   }
 }

--- a/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
+++ b/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
@@ -4,9 +4,12 @@ import com.followMe.common.pagination.CursorRequest;
 import com.followMe.common.pagination.CursorResponse;
 import com.followMe.order_server.order.application.dto.request.OrderCreateRequest;
 import com.followMe.order_server.order.application.dto.request.OrderSearchCondition;
+import com.followMe.order_server.order.application.dto.request.OrderUpdateRequest;
+import com.followMe.order_server.order.application.dto.request.OrderUpdateStateRequest;
 import com.followMe.order_server.order.application.dto.request.UserContext;
 import com.followMe.order_server.order.application.dto.response.OrderResponse;
 import com.followMe.order_server.order.domain.Order;
+import com.followMe.order_server.order.domain.OrderState;
 import com.followMe.order_server.order.domain.ProductInfo;
 import com.followMe.order_server.order.domain.VendorInfo;
 import com.followMe.order_server.order.domain.repository.OrderRepository;
@@ -59,11 +62,14 @@ public class OrderServiceImpl implements OrderService {
   }
 
   @Override
+  @Transactional(readOnly = true)
   public OrderResponse readById(UUID orderId) {
     Order order = orderRepository.findById(orderId);
     return OrderResponse.from(order);
   }
 
+  @Override
+  @Transactional(readOnly = true)
   public CursorResponse<OrderResponse> search(
       CursorRequest cursorRequest, OrderSearchCondition condition, UserContext userContext) {
     OrderSearchCondition filteredCondition =
@@ -78,5 +84,35 @@ public class OrderServiceImpl implements OrderService {
         cursorRequest.getSize(),
         OrderResponse::from,
         order -> order.getOrderId().toString());
+  }
+
+  @Override
+  @Transactional
+  public void update(UUID orderId, OrderUpdateRequest updateRequest) {
+    Order order = orderRepository.findById(orderId);
+
+    if (updateRequest.requestNote() != null) {
+      order.updateRequestNote(updateRequest.requestNote());
+    }
+
+    if (updateRequest.quantity() != null) {
+      // TODO: 허브에게 재고확인
+      order.updateQuantity(updateRequest.quantity());
+    }
+  }
+
+  @Override
+  @Transactional
+  public void updateStatus(UUID orderId, OrderUpdateStateRequest updateStateRequest) {
+    Order order = orderRepository.findById(orderId);
+    OrderState updatedState = OrderState.valueOf(updateStateRequest.status().toUpperCase());
+    order.updateState(updatedState);
+  }
+
+  @Override
+  @Transactional
+  public void softDeleteById(UUID orderId) {
+    Order order = orderRepository.findById(orderId);
+    order.softDelete(orderId);
   }
 }

--- a/src/main/java/com/followMe/order_server/order/application/dto/request/OrderCreateRequest.java
+++ b/src/main/java/com/followMe/order_server/order/application/dto/request/OrderCreateRequest.java
@@ -7,7 +7,9 @@ public record OrderCreateRequest(
     String productName,
     UUID requestVendorId,
     String requestVendorName,
+    UUID requestVendorHubId,
     UUID receiverVendorId,
     String receiverVendorName,
+    UUID receiverVendorHubId,
     int quantity,
     String requestNote) {}

--- a/src/main/java/com/followMe/order_server/order/application/dto/request/OrderSearchCondition.java
+++ b/src/main/java/com/followMe/order_server/order/application/dto/request/OrderSearchCondition.java
@@ -1,0 +1,16 @@
+package com.followMe.order_server.order.application.dto.request;
+
+import com.followMe.order_server.order.domain.OrderState;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record OrderSearchCondition(
+    UUID hubId,
+    UUID productId,
+    UUID orderId,
+    String productName,
+    LocalDateTime startDateTime,
+    LocalDateTime endDateTime,
+    UUID createdBy,
+    UUID vendorId,
+    OrderState status) {}

--- a/src/main/java/com/followMe/order_server/order/application/dto/request/OrderUpdateRequest.java
+++ b/src/main/java/com/followMe/order_server/order/application/dto/request/OrderUpdateRequest.java
@@ -1,0 +1,3 @@
+package com.followMe.order_server.order.application.dto.request;
+
+public record OrderUpdateRequest(String requestNote, Integer quantity) {}

--- a/src/main/java/com/followMe/order_server/order/application/dto/request/OrderUpdateStateRequest.java
+++ b/src/main/java/com/followMe/order_server/order/application/dto/request/OrderUpdateStateRequest.java
@@ -1,0 +1,3 @@
+package com.followMe.order_server.order.application.dto.request;
+
+public record OrderUpdateStateRequest(String status) {}

--- a/src/main/java/com/followMe/order_server/order/application/dto/request/UserContext.java
+++ b/src/main/java/com/followMe/order_server/order/application/dto/request/UserContext.java
@@ -1,0 +1,5 @@
+package com.followMe.order_server.order.application.dto.request;
+
+import java.util.UUID;
+
+public record UserContext(UUID userId, UserRole userRole, UUID hubId, UUID vendorId) {}

--- a/src/main/java/com/followMe/order_server/order/application/dto/request/UserRole.java
+++ b/src/main/java/com/followMe/order_server/order/application/dto/request/UserRole.java
@@ -1,0 +1,8 @@
+package com.followMe.order_server.order.application.dto.request;
+
+public enum UserRole {
+  VENDOR,
+  DELIVERY_MANAGER,
+  HUB_MANAGER,
+  MASTER;
+}

--- a/src/main/java/com/followMe/order_server/order/application/dto/response/OrderResponse.java
+++ b/src/main/java/com/followMe/order_server/order/application/dto/response/OrderResponse.java
@@ -1,0 +1,38 @@
+package com.followMe.order_server.order.application.dto.response;
+
+import com.followMe.order_server.order.domain.Order;
+import com.followMe.order_server.order.domain.OrderState;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record OrderResponse(
+    UUID orderId,
+    UUID deliveryId,
+    UUID productid,
+    String productName,
+    int quantity,
+    UUID requestVendorId,
+    String requestVendorName,
+    UUID receiverVendorId,
+    String receiverVendorName,
+    String requestNote,
+    OrderState status,
+    LocalDateTime cancelledAt,
+    UUID cancelledBy) {
+  public static OrderResponse from(Order order) {
+    return new OrderResponse(
+        order.getOrderId(),
+        order.getDeliveryId(),
+        order.getProductInfo().getProductId(),
+        order.getProductInfo().getProductName(),
+        order.getProductInfo().getQuantity(),
+        order.getRequestVendor().getVendorId(),
+        order.getRequestVendor().getVendorName(),
+        order.getReceiverVendor().getVendorId(),
+        order.getReceiverVendor().getVendorName(),
+        order.getRequestNote(),
+        order.getStatus(),
+        order.getCancelledAt(),
+        order.getCancelledBy());
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/config/QueryDslConfig.java
+++ b/src/main/java/com/followMe/order_server/order/config/QueryDslConfig.java
@@ -1,0 +1,15 @@
+package com.followMe.order_server.order.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/config/audit/CurrentUserHolder.java
+++ b/src/main/java/com/followMe/order_server/order/config/audit/CurrentUserHolder.java
@@ -1,0 +1,17 @@
+package com.followMe.order_server.order.config.audit;
+
+public class CurrentUserHolder {
+  private static final ThreadLocal<String> holder = new ThreadLocal<>();
+
+  public static void set(String userId) {
+    holder.set(userId);
+  }
+
+  public static String get() {
+    return holder.get();
+  }
+
+  public static void clear() {
+    holder.remove();
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/config/audit/JpaConfig.java
+++ b/src/main/java/com/followMe/order_server/order/config/audit/JpaConfig.java
@@ -1,0 +1,16 @@
+package com.followMe.order_server.order.config.audit;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+
+@Configuration
+public class JpaConfig {
+
+  @Bean
+  public AuditorAware<UUID> auditorAware() {
+    return () -> Optional.ofNullable(CurrentUserHolder.get()).map(UUID::fromString);
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/config/audit/UserInterceptor.java
+++ b/src/main/java/com/followMe/order_server/order/config/audit/UserInterceptor.java
@@ -1,0 +1,26 @@
+package com.followMe.order_server.order.config.audit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class UserInterceptor implements HandlerInterceptor {
+
+  @Override
+  public boolean preHandle(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
+    String userId = request.getHeader("X-User-Id");
+    if (userId != null) {
+      CurrentUserHolder.set(userId);
+    }
+    return true;
+  }
+
+  @Override
+  public void afterCompletion(
+      HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+    CurrentUserHolder.clear();
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/config/audit/WebConfig.java
+++ b/src/main/java/com/followMe/order_server/order/config/audit/WebConfig.java
@@ -1,0 +1,20 @@
+package com.followMe.order_server.order.config.audit;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  private final UserInterceptor userInterceptor;
+
+  public WebConfig(UserInterceptor userInterceptor) {
+    this.userInterceptor = userInterceptor;
+  }
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(userInterceptor);
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/domain/BaseAudit2.java
+++ b/src/main/java/com/followMe/order_server/order/domain/BaseAudit2.java
@@ -1,0 +1,45 @@
+package com.followMe.order_server.order.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.util.UUID;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 생성/수정 시각 + 작성자 정보까지 관리하는 기반 엔티티.
+ *
+ * <p>소비자 서비스에서 {@code AuditorAware<String>} 빈을 등록해야 합니다.
+ *
+ * <pre>{@code
+ * @Bean
+ * public AuditorAware<String> auditorAware() {
+ *     return () -> Optional.ofNullable(SecurityContextHolder.getContext())
+ *         .map(ctx -> ctx.getAuthentication().getName());
+ * }
+ * }</pre>
+ */
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseAudit2 extends BaseTime2 {
+
+  @CreatedBy
+  @Column(nullable = false, updatable = false, length = 100)
+  private UUID createdBy;
+
+  @LastModifiedBy
+  @Column(nullable = false, length = 100)
+  private UUID updatedBy;
+
+  @Column(length = 100)
+  private UUID deletedBy;
+
+  public void softDelete(UUID deletedBy) {
+    super.softDelete();
+    this.deletedBy = deletedBy;
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/domain/BaseTime2.java
+++ b/src/main/java/com/followMe/order_server/order/domain/BaseTime2.java
@@ -1,0 +1,45 @@
+package com.followMe.order_server.order.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.Instant;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 생성/수정 시각만 관리하는 기반 엔티티.
+ *
+ * <p>소비자 서비스에서 반드시 {@code @EnableJpaAuditing} 을 선언해야 합니다.
+ *
+ * <pre>{@code
+ * @EnableJpaAuditing
+ * @SpringBootApplication
+ * public class MyServiceApplication { ... }
+ * }</pre>
+ */
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTime2 {
+
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private Instant createdAt;
+
+  @LastModifiedDate
+  @Column(nullable = false)
+  private Instant updatedAt;
+
+  @Column private Instant deletedAt;
+
+  public boolean isDeleted() {
+    return deletedAt != null;
+  }
+
+  public void softDelete() {
+    this.deletedAt = Instant.now();
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/domain/Order.java
+++ b/src/main/java/com/followMe/order_server/order/domain/Order.java
@@ -1,6 +1,5 @@
 package com.followMe.order_server.order.domain;
 
-import com.followMe.common.entity.BaseAudit;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
@@ -21,7 +20,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "p_order")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Order extends BaseAudit {
+public class Order extends BaseAudit2 {
 
   @Id
   @Column(name = "order_id")
@@ -35,14 +34,16 @@ public class Order extends BaseAudit {
   @Embedded
   @AttributeOverrides({
     @AttributeOverride(name = "vendorId", column = @Column(name = "request_vendor_id")),
-    @AttributeOverride(name = "vendorName", column = @Column(name = "request_vendor_name"))
+    @AttributeOverride(name = "vendorName", column = @Column(name = "request_vendor_name")),
+    @AttributeOverride(name = "hubId", column = @Column(name = "request_vendor_hub_id"))
   })
   private VendorInfo requestVendor;
 
   @Embedded
   @AttributeOverrides({
     @AttributeOverride(name = "vendorId", column = @Column(name = "receiver_vendor_id")),
-    @AttributeOverride(name = "vendorName", column = @Column(name = "receiver_vendor_name"))
+    @AttributeOverride(name = "vendorName", column = @Column(name = "receiver_vendor_name")),
+    @AttributeOverride(name = "hubId", column = @Column(name = "receiver_vendor_hub_id"))
   })
   private VendorInfo receiverVendor;
 

--- a/src/main/java/com/followMe/order_server/order/domain/Order.java
+++ b/src/main/java/com/followMe/order_server/order/domain/Order.java
@@ -103,4 +103,20 @@ public class Order extends BaseAudit2 {
     this.cancelledAt = LocalDateTime.now();
     this.cancelledBy = userId;
   }
+
+  public void updateRequestNote(String requestNote) {
+    this.requestNote = requestNote;
+  }
+
+  // TODO : 수정 시 재고 검증
+  public void updateQuantity(int quantity) {
+    ProductInfo updatedProductInfo =
+        new ProductInfo(
+            this.productInfo.getProductId(), this.productInfo.getProductName(), quantity);
+    this.productInfo = updatedProductInfo;
+  }
+
+  public void updateState(OrderState status) {
+    this.status = status;
+  }
 }

--- a/src/main/java/com/followMe/order_server/order/domain/VendorInfo.java
+++ b/src/main/java/com/followMe/order_server/order/domain/VendorInfo.java
@@ -13,13 +13,16 @@ public class VendorInfo {
 
   private UUID vendorId;
   private String vendorName;
+  private UUID hubId;
 
-  public VendorInfo(UUID vendorId, String vendorName) {
+  public VendorInfo(UUID vendorId, String vendorName, UUID hubId) {
     if (vendorId == null) throw new IllegalArgumentException("vendorId 필수");
     if (vendorName == null || vendorName.isBlank())
       throw new IllegalArgumentException("vendorName 필수");
+    if (hubId == null) throw new IllegalArgumentException("hubId 필수");
 
     this.vendorId = vendorId;
     this.vendorName = vendorName;
+    this.hubId = hubId;
   }
 }

--- a/src/main/java/com/followMe/order_server/order/domain/exception/OrderErrorCode.java
+++ b/src/main/java/com/followMe/order_server/order/domain/exception/OrderErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum OrderErrorCode implements ErrorCode {
   DELIVERY_NOT_FOUND("D001", "배달을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-  DELIVERY_CLIENT_UNAVAILABLE("D002", "배달 서비스를 일시적으로 사용할 수 없습니다.", HttpStatus.SERVICE_UNAVAILABLE);
+  DELIVERY_CLIENT_UNAVAILABLE("D002", "배달 서비스를 일시적으로 사용할 수 없습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+  ORDER_NOT_FOUND("O001", "해당 ID의 주문을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
   private final String code;
   private final String message;

--- a/src/main/java/com/followMe/order_server/order/domain/exception/OrderNotFoundException.java
+++ b/src/main/java/com/followMe/order_server/order/domain/exception/OrderNotFoundException.java
@@ -1,0 +1,9 @@
+package com.followMe.order_server.order.domain.exception;
+
+import com.followMe.common.exception.BusinessException;
+
+public class OrderNotFoundException extends BusinessException {
+  public OrderNotFoundException() {
+    super(OrderErrorCode.ORDER_NOT_FOUND);
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/followMe/order_server/order/domain/repository/OrderRepository.java
@@ -1,6 +1,8 @@
 package com.followMe.order_server.order.domain.repository;
 
+import com.followMe.order_server.order.application.dto.request.OrderSearchCondition;
 import com.followMe.order_server.order.domain.Order;
+import java.util.List;
 import java.util.UUID;
 
 public interface OrderRepository {
@@ -8,4 +10,6 @@ public interface OrderRepository {
   void save(Order order);
 
   Order findById(UUID orderId);
+
+  List<Order> searchByCursor(String cursor, int size, OrderSearchCondition condition);
 }

--- a/src/main/java/com/followMe/order_server/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/followMe/order_server/order/domain/repository/OrderRepository.java
@@ -1,8 +1,11 @@
 package com.followMe.order_server.order.domain.repository;
 
 import com.followMe.order_server.order.domain.Order;
+import java.util.UUID;
 
 public interface OrderRepository {
 
   void save(Order order);
+
+  Order findById(UUID orderId);
 }

--- a/src/main/java/com/followMe/order_server/order/infrastructure/client/repository/OrderRepositoryAdapter.java
+++ b/src/main/java/com/followMe/order_server/order/infrastructure/client/repository/OrderRepositoryAdapter.java
@@ -39,7 +39,6 @@ public class OrderRepositoryAdapter implements OrderRepository {
     return jpaQueryFactory
         .selectFrom(order)
         .where(
-            cursorLt(cursor),
             hubEq(condition.hubId()),
             productIdEq(condition.productId()),
             orderIdEq(condition.orderId()),
@@ -52,13 +51,6 @@ public class OrderRepositoryAdapter implements OrderRepository {
         .orderBy(order.createdAt.desc(), order.orderId.desc()) // 안정적인 커서 페이징
         .limit(size)
         .fetch();
-  }
-
-  private BooleanExpression cursorLt(String cursor) {
-    if (cursor == null) return null;
-
-    LocalDateTime cursorTime = LocalDateTime.parse(cursor);
-    return QOrder.order.createdAt.lt(Instant.from(cursorTime));
   }
 
   private BooleanExpression hubEq(UUID hubId) {

--- a/src/main/java/com/followMe/order_server/order/infrastructure/client/repository/OrderRepositoryAdapter.java
+++ b/src/main/java/com/followMe/order_server/order/infrastructure/client/repository/OrderRepositoryAdapter.java
@@ -1,8 +1,16 @@
 package com.followMe.order_server.order.infrastructure.client.repository;
 
+import com.followMe.order_server.order.application.dto.request.OrderSearchCondition;
 import com.followMe.order_server.order.domain.Order;
+import com.followMe.order_server.order.domain.OrderState;
+import com.followMe.order_server.order.domain.QOrder;
 import com.followMe.order_server.order.domain.exception.OrderNotFoundException;
 import com.followMe.order_server.order.domain.repository.OrderRepository;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -12,6 +20,7 @@ import org.springframework.stereotype.Repository;
 public class OrderRepositoryAdapter implements OrderRepository {
 
   private final OrderJpaRepository orderJpaRepository;
+  private final JPAQueryFactory jpaQueryFactory;
 
   @Override
   public void save(Order order) {
@@ -21,5 +30,83 @@ public class OrderRepositoryAdapter implements OrderRepository {
   @Override
   public Order findById(UUID orderId) {
     return orderJpaRepository.findById(orderId).orElseThrow(OrderNotFoundException::new);
+  }
+
+  public List<Order> searchByCursor(String cursor, int size, OrderSearchCondition condition) {
+
+    QOrder order = QOrder.order;
+
+    return jpaQueryFactory
+        .selectFrom(order)
+        .where(
+            cursorLt(cursor),
+            hubEq(condition.hubId()),
+            productIdEq(condition.productId()),
+            orderIdEq(condition.orderId()),
+            productNameContains(condition.productName()),
+            createdAtGoe(condition.startDateTime()),
+            createdAtLoe(condition.endDateTime()),
+            createdByEq(condition.createdBy()),
+            vendorEq(condition.vendorId()),
+            statusEq(condition.status()))
+        .orderBy(order.createdAt.desc(), order.orderId.desc()) // 안정적인 커서 페이징
+        .limit(size)
+        .fetch();
+  }
+
+  private BooleanExpression cursorLt(String cursor) {
+    if (cursor == null) return null;
+
+    LocalDateTime cursorTime = LocalDateTime.parse(cursor);
+    return QOrder.order.createdAt.lt(Instant.from(cursorTime));
+  }
+
+  private BooleanExpression hubEq(UUID hubId) {
+    if (hubId == null) return null;
+
+    QOrder order = QOrder.order;
+    return order.requestVendor.hubId.eq(hubId).or(order.receiverVendor.hubId.eq(hubId));
+  }
+
+  private BooleanExpression productIdEq(UUID productId) {
+    if (productId == null) return null;
+    return QOrder.order.productInfo.productId.eq(productId);
+  }
+
+  private BooleanExpression orderIdEq(UUID orderId) {
+    if (orderId == null) return null;
+    return QOrder.order.orderId.eq(orderId);
+  }
+
+  private BooleanExpression productNameContains(String productName) {
+    if (productName == null || productName.isBlank()) return null;
+    return QOrder.order.productInfo.productName.contains(productName);
+  }
+
+  private BooleanExpression createdAtGoe(LocalDateTime start) {
+    if (start == null) return null;
+    return QOrder.order.createdAt.goe(Instant.from(start));
+  }
+
+  private BooleanExpression createdAtLoe(LocalDateTime end) {
+    if (end == null) return null;
+    return QOrder.order.createdAt.loe(Instant.from(end));
+  }
+
+  private BooleanExpression createdByEq(UUID createdBy) {
+    if (createdBy == null) return null;
+    return QOrder.order.createdBy.eq(createdBy);
+  }
+
+  private BooleanExpression vendorEq(UUID vendorId) {
+    if (vendorId == null) return null;
+
+    QOrder order = QOrder.order;
+    return order.requestVendor.vendorId.eq(vendorId).or(order.receiverVendor.vendorId.eq(vendorId));
+  }
+
+  private BooleanExpression statusEq(OrderState status) {
+    if (status == null) return null;
+    return QOrder.order.status.eq(status);
   }
 }

--- a/src/main/java/com/followMe/order_server/order/infrastructure/client/repository/OrderRepositoryAdapter.java
+++ b/src/main/java/com/followMe/order_server/order/infrastructure/client/repository/OrderRepositoryAdapter.java
@@ -1,7 +1,9 @@
 package com.followMe.order_server.order.infrastructure.client.repository;
 
 import com.followMe.order_server.order.domain.Order;
+import com.followMe.order_server.order.domain.exception.OrderNotFoundException;
 import com.followMe.order_server.order.domain.repository.OrderRepository;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -14,5 +16,10 @@ public class OrderRepositoryAdapter implements OrderRepository {
   @Override
   public void save(Order order) {
     orderJpaRepository.save(order);
+  }
+
+  @Override
+  public Order findById(UUID orderId) {
+    return orderJpaRepository.findById(orderId).orElseThrow(OrderNotFoundException::new);
   }
 }

--- a/src/main/java/com/followMe/order_server/order/presentation/OrderController.java
+++ b/src/main/java/com/followMe/order_server/order/presentation/OrderController.java
@@ -3,8 +3,12 @@ package com.followMe.order_server.order.presentation;
 import com.followMe.common.response.ApiResponse;
 import com.followMe.order_server.order.application.OrderService;
 import com.followMe.order_server.order.application.dto.request.OrderCreateRequest;
+import com.followMe.order_server.order.application.dto.response.OrderResponse;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/order")
+@RequestMapping("/api/v1/orders")
 public class OrderController {
 
   private final OrderService orderService;
@@ -22,4 +26,11 @@ public class OrderController {
     orderService.create(createRequest);
     return ApiResponse.created();
   }
+
+  @GetMapping("/{orderId}")
+  public ResponseEntity<ApiResponse> readById(@PathVariable UUID orderId) {
+    OrderResponse response = orderService.readById(orderId);
+    return ApiResponse.ok(response);
+  }
+
 }

--- a/src/main/java/com/followMe/order_server/order/presentation/OrderController.java
+++ b/src/main/java/com/followMe/order_server/order/presentation/OrderController.java
@@ -6,14 +6,19 @@ import com.followMe.common.response.ApiResponse;
 import com.followMe.order_server.order.application.OrderService;
 import com.followMe.order_server.order.application.dto.request.OrderCreateRequest;
 import com.followMe.order_server.order.application.dto.request.OrderSearchCondition;
+import com.followMe.order_server.order.application.dto.request.OrderUpdateRequest;
+import com.followMe.order_server.order.application.dto.request.OrderUpdateStateRequest;
 import com.followMe.order_server.order.application.dto.request.UserContext;
 import com.followMe.order_server.order.application.dto.request.UserRole;
 import com.followMe.order_server.order.application.dto.response.OrderResponse;
+import com.followMe.order_server.order.infrastructure.client.repository.OrderRepositoryAdapter;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrderController {
 
   private final OrderService orderService;
+  private final OrderRepositoryAdapter orderRepositoryAdapter;
 
   @ModelAttribute
   public UserContext userContext(
@@ -58,5 +64,25 @@ public class OrderController {
     CursorResponse<OrderResponse> response =
         orderService.search(cursorRequest, condition, userContext);
     return ApiResponse.ok(response);
+  }
+
+  @PatchMapping("/{orderId}")
+  public ResponseEntity<ApiResponse> update(
+      @PathVariable UUID orderId, @RequestBody OrderUpdateRequest updateRequest) {
+    orderService.update(orderId, updateRequest);
+    return ApiResponse.ok();
+  }
+
+  @PatchMapping("/{orderId}/state")
+  public ResponseEntity<ApiResponse> updateStatus(
+      @PathVariable UUID orderId, @RequestBody OrderUpdateStateRequest updateStateRequest) {
+    orderService.updateStatus(orderId, updateStateRequest);
+    return ApiResponse.ok();
+  }
+
+  @DeleteMapping("/{orderId}")
+  public ResponseEntity<ApiResponse> delete(@PathVariable UUID orderId) {
+    orderService.softDeleteById(orderId);
+    return ApiResponse.ok();
   }
 }

--- a/src/main/java/com/followMe/order_server/order/presentation/OrderController.java
+++ b/src/main/java/com/followMe/order_server/order/presentation/OrderController.java
@@ -1,16 +1,23 @@
 package com.followMe.order_server.order.presentation;
 
+import com.followMe.common.pagination.CursorRequest;
+import com.followMe.common.pagination.CursorResponse;
 import com.followMe.common.response.ApiResponse;
 import com.followMe.order_server.order.application.OrderService;
 import com.followMe.order_server.order.application.dto.request.OrderCreateRequest;
+import com.followMe.order_server.order.application.dto.request.OrderSearchCondition;
+import com.followMe.order_server.order.application.dto.request.UserContext;
+import com.followMe.order_server.order.application.dto.request.UserRole;
 import com.followMe.order_server.order.application.dto.response.OrderResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,6 +27,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrderController {
 
   private final OrderService orderService;
+
+  @ModelAttribute
+  public UserContext userContext(
+      @RequestHeader("X-User-Id") UUID userId,
+      @RequestHeader("X-User-Role") UserRole role,
+      @RequestHeader(value = "X-Hub-Id", required = false) UUID hubId,
+      @RequestHeader(value = "X-Vendor-Id", required = false) UUID vendorId) {
+    return new UserContext(userId, role, hubId, vendorId);
+  }
 
   @PostMapping
   public ResponseEntity<ApiResponse> create(@RequestBody OrderCreateRequest createRequest) {
@@ -33,4 +49,14 @@ public class OrderController {
     return ApiResponse.ok(response);
   }
 
+  @GetMapping
+  public ResponseEntity<ApiResponse> search(
+      @ModelAttribute CursorRequest cursorRequest,
+      @ModelAttribute OrderSearchCondition condition,
+      @ModelAttribute UserContext userContext) {
+    // TODO: 인증/인가에 따라 UserContext 변경 가능
+    CursorResponse<OrderResponse> response =
+        orderService.search(cursorRequest, condition, userContext);
+    return ApiResponse.ok(response);
+  }
 }

--- a/src/main/java/com/followMe/order_server/order/presentation/OrderController.java
+++ b/src/main/java/com/followMe/order_server/order/presentation/OrderController.java
@@ -57,7 +57,7 @@ public class OrderController {
 
   @GetMapping
   public ResponseEntity<ApiResponse> search(
-      @ModelAttribute CursorRequest cursorRequest,
+      CursorRequest cursorRequest,
       @ModelAttribute OrderSearchCondition condition,
       @ModelAttribute UserContext userContext) {
     // TODO: 인증/인가에 따라 UserContext 변경 가능

--- a/src/main/java/com/followMe/order_server/order/presentation/OrderInternalController.java
+++ b/src/main/java/com/followMe/order_server/order/presentation/OrderInternalController.java
@@ -1,12 +1,26 @@
 package com.followMe.order_server.order.presentation;
 
+import com.followMe.common.response.ApiResponse;
 import com.followMe.order_server.order.application.OrderService;
+import com.followMe.order_server.order.application.dto.response.OrderResponse;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/internal/v1/orders")
 public class OrderInternalController {
 
   private final OrderService orderService;
+
+  @GetMapping("/{orderId}")
+  public ResponseEntity<ApiResponse> readById(@PathVariable UUID orderId) {
+    OrderResponse response = orderService.readById(orderId);
+    return ApiResponse.ok(response);
+  }
 }

--- a/src/main/java/com/followMe/order_server/order/presentation/OrderInternalController.java
+++ b/src/main/java/com/followMe/order_server/order/presentation/OrderInternalController.java
@@ -2,12 +2,16 @@ package com.followMe.order_server.order.presentation;
 
 import com.followMe.common.response.ApiResponse;
 import com.followMe.order_server.order.application.OrderService;
+import com.followMe.order_server.order.application.dto.request.OrderUpdateStateRequest;
 import com.followMe.order_server.order.application.dto.response.OrderResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,5 +26,18 @@ public class OrderInternalController {
   public ResponseEntity<ApiResponse> readById(@PathVariable UUID orderId) {
     OrderResponse response = orderService.readById(orderId);
     return ApiResponse.ok(response);
+  }
+
+  @PatchMapping("/{orderId}/status")
+  public ResponseEntity<ApiResponse> updateStatus(
+      @PathVariable UUID orderId, @RequestBody OrderUpdateStateRequest updateStateRequest) {
+    orderService.updateStatus(orderId, updateStateRequest);
+    return ApiResponse.ok();
+  }
+
+  @DeleteMapping("/{orderId}")
+  public ResponseEntity<ApiResponse> delete(@PathVariable UUID orderId) {
+    orderService.softDeleteById(orderId);
+    return ApiResponse.ok();
   }
 }


### PR DESCRIPTION
### 📌 관련 이슈
- close #5 
- #9 이후 주문 재고 수정에 대한 검증 로직이 추가 예정.
- 배송 담당자 변경 내부 API는 #11 및 4/1 오전 스크럼 이후 진행 예정
- 각 수정 및 삭제에 대한 인가 로직은 인증/인가 서버 구현 이후 추가 예정
 
### 💡 작업 내용

- 주문 수정
- 주문 삭제 
- 상태 변경

### 🔍 변경 이유

### 📝 리뷰 포인트 (선택)

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)