### PR TITLE
[FEAT] 주문 수정, 상태 변경, 삭제 API 구현

### DIFF
--- a/src/main/java/com/followMe/order_server/order/application/OrderService.java
+++ b/src/main/java/com/followMe/order_server/order/application/OrderService.java
@@ -4,6 +4,8 @@ import com.followMe.common.pagination.CursorRequest;
 import com.followMe.common.pagination.CursorResponse;
 import com.followMe.order_server.order.application.dto.request.OrderCreateRequest;
 import com.followMe.order_server.order.application.dto.request.OrderSearchCondition;
+import com.followMe.order_server.order.application.dto.request.OrderUpdateRequest;
+import com.followMe.order_server.order.application.dto.request.OrderUpdateStateRequest;
 import com.followMe.order_server.order.application.dto.request.UserContext;
 import com.followMe.order_server.order.application.dto.response.OrderResponse;
 import java.util.UUID;
@@ -15,4 +17,10 @@ public interface OrderService {
 
   CursorResponse<OrderResponse> search(
       CursorRequest cursorRequest, OrderSearchCondition condition, UserContext userContext);
+
+  void update(UUID orderId, OrderUpdateRequest updateRequest);
+
+  void updateStatus(UUID orderId, OrderUpdateStateRequest updateStateRequest);
+
+  void softDeleteById(UUID orderId);
 }

--- a/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
+++ b/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
@@ -4,9 +4,12 @@ import com.followMe.common.pagination.CursorRequest;
 import com.followMe.common.pagination.CursorResponse;
 import com.followMe.order_server.order.application.dto.request.OrderCreateRequest;
 import com.followMe.order_server.order.application.dto.request.OrderSearchCondition;
+import com.followMe.order_server.order.application.dto.request.OrderUpdateRequest;
+import com.followMe.order_server.order.application.dto.request.OrderUpdateStateRequest;
 import com.followMe.order_server.order.application.dto.request.UserContext;
 import com.followMe.order_server.order.application.dto.response.OrderResponse;
 import com.followMe.order_server.order.domain.Order;
+import com.followMe.order_server.order.domain.OrderState;
 import com.followMe.order_server.order.domain.ProductInfo;
 import com.followMe.order_server.order.domain.VendorInfo;
 import com.followMe.order_server.order.domain.repository.OrderRepository;
@@ -59,11 +62,14 @@ public class OrderServiceImpl implements OrderService {
   }
 
   @Override
+  @Transactional(readOnly = true)
   public OrderResponse readById(UUID orderId) {
     Order order = orderRepository.findById(orderId);
     return OrderResponse.from(order);
   }
 
+  @Override
+  @Transactional(readOnly = true)
   public CursorResponse<OrderResponse> search(
       CursorRequest cursorRequest, OrderSearchCondition condition, UserContext userContext) {
     OrderSearchCondition filteredCondition =
@@ -78,5 +84,35 @@ public class OrderServiceImpl implements OrderService {
         cursorRequest.getSize(),
         OrderResponse::from,
         order -> order.getOrderId().toString());
+  }
+
+  @Override
+  @Transactional
+  public void update(UUID orderId, OrderUpdateRequest updateRequest) {
+    Order order = orderRepository.findById(orderId);
+
+    if (updateRequest.requestNote() != null) {
+      order.updateRequestNote(updateRequest.requestNote());
+    }
+
+    if (updateRequest.quantity() != null) {
+      // TODO: 허브에게 재고확인
+      order.updateQuantity(updateRequest.quantity());
+    }
+  }
+
+  @Override
+  @Transactional
+  public void updateStatus(UUID orderId, OrderUpdateStateRequest updateStateRequest) {
+    Order order = orderRepository.findById(orderId);
+    OrderState updatedState = OrderState.valueOf(updateStateRequest.status().toUpperCase());
+    order.updateState(updatedState);
+  }
+
+  @Override
+  @Transactional
+  public void softDeleteById(UUID orderId) {
+    Order order = orderRepository.findById(orderId);
+    order.softDelete(orderId);
   }
 }

--- a/src/main/java/com/followMe/order_server/order/application/dto/request/OrderUpdateRequest.java
+++ b/src/main/java/com/followMe/order_server/order/application/dto/request/OrderUpdateRequest.java
@@ -1,0 +1,3 @@
+package com.followMe.order_server.order.application.dto.request;
+
+public record OrderUpdateRequest(String requestNote, Integer quantity) {}

--- a/src/main/java/com/followMe/order_server/order/application/dto/request/OrderUpdateStateRequest.java
+++ b/src/main/java/com/followMe/order_server/order/application/dto/request/OrderUpdateStateRequest.java
@@ -1,0 +1,3 @@
+package com.followMe.order_server.order.application.dto.request;
+
+public record OrderUpdateStateRequest(String status) {}

--- a/src/main/java/com/followMe/order_server/order/domain/Order.java
+++ b/src/main/java/com/followMe/order_server/order/domain/Order.java
@@ -103,4 +103,20 @@ public class Order extends BaseAudit2 {
     this.cancelledAt = LocalDateTime.now();
     this.cancelledBy = userId;
   }
+
+  public void updateRequestNote(String requestNote) {
+    this.requestNote = requestNote;
+  }
+
+  // TODO : 수정 시 재고 검증
+  public void updateQuantity(int quantity) {
+    ProductInfo updatedProductInfo =
+        new ProductInfo(
+            this.productInfo.getProductId(), this.productInfo.getProductName(), quantity);
+    this.productInfo = updatedProductInfo;
+  }
+
+  public void updateState(OrderState status) {
+    this.status = status;
+  }
 }

--- a/src/main/java/com/followMe/order_server/order/infrastructure/client/repository/OrderRepositoryAdapter.java
+++ b/src/main/java/com/followMe/order_server/order/infrastructure/client/repository/OrderRepositoryAdapter.java
@@ -39,7 +39,6 @@ public class OrderRepositoryAdapter implements OrderRepository {
     return jpaQueryFactory
         .selectFrom(order)
         .where(
-            cursorLt(cursor),
             hubEq(condition.hubId()),
             productIdEq(condition.productId()),
             orderIdEq(condition.orderId()),
@@ -52,13 +51,6 @@ public class OrderRepositoryAdapter implements OrderRepository {
         .orderBy(order.createdAt.desc(), order.orderId.desc()) // 안정적인 커서 페이징
         .limit(size)
         .fetch();
-  }
-
-  private BooleanExpression cursorLt(String cursor) {
-    if (cursor == null) return null;
-
-    LocalDateTime cursorTime = LocalDateTime.parse(cursor);
-    return QOrder.order.createdAt.lt(Instant.from(cursorTime));
   }
 
   private BooleanExpression hubEq(UUID hubId) {

--- a/src/main/java/com/followMe/order_server/order/presentation/OrderController.java
+++ b/src/main/java/com/followMe/order_server/order/presentation/OrderController.java
@@ -6,14 +6,19 @@ import com.followMe.common.response.ApiResponse;
 import com.followMe.order_server.order.application.OrderService;
 import com.followMe.order_server.order.application.dto.request.OrderCreateRequest;
 import com.followMe.order_server.order.application.dto.request.OrderSearchCondition;
+import com.followMe.order_server.order.application.dto.request.OrderUpdateRequest;
+import com.followMe.order_server.order.application.dto.request.OrderUpdateStateRequest;
 import com.followMe.order_server.order.application.dto.request.UserContext;
 import com.followMe.order_server.order.application.dto.request.UserRole;
 import com.followMe.order_server.order.application.dto.response.OrderResponse;
+import com.followMe.order_server.order.infrastructure.client.repository.OrderRepositoryAdapter;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrderController {
 
   private final OrderService orderService;
+  private final OrderRepositoryAdapter orderRepositoryAdapter;
 
   @ModelAttribute
   public UserContext userContext(
@@ -58,5 +64,25 @@ public class OrderController {
     CursorResponse<OrderResponse> response =
         orderService.search(cursorRequest, condition, userContext);
     return ApiResponse.ok(response);
+  }
+
+  @PatchMapping("/{orderId}")
+  public ResponseEntity<ApiResponse> update(
+      @PathVariable UUID orderId, @RequestBody OrderUpdateRequest updateRequest) {
+    orderService.update(orderId, updateRequest);
+    return ApiResponse.ok();
+  }
+
+  @PatchMapping("/{orderId}/state")
+  public ResponseEntity<ApiResponse> updateStatus(
+      @PathVariable UUID orderId, @RequestBody OrderUpdateStateRequest updateStateRequest) {
+    orderService.updateStatus(orderId, updateStateRequest);
+    return ApiResponse.ok();
+  }
+
+  @DeleteMapping("/{orderId}")
+  public ResponseEntity<ApiResponse> delete(@PathVariable UUID orderId) {
+    orderService.softDeleteById(orderId);
+    return ApiResponse.ok();
   }
 }

--- a/src/main/java/com/followMe/order_server/order/presentation/OrderController.java
+++ b/src/main/java/com/followMe/order_server/order/presentation/OrderController.java
@@ -57,7 +57,7 @@ public class OrderController {
 
   @GetMapping
   public ResponseEntity<ApiResponse> search(
-      @ModelAttribute CursorRequest cursorRequest,
+      CursorRequest cursorRequest,
       @ModelAttribute OrderSearchCondition condition,
       @ModelAttribute UserContext userContext) {
     // TODO: 인증/인가에 따라 UserContext 변경 가능

--- a/src/main/java/com/followMe/order_server/order/presentation/OrderInternalController.java
+++ b/src/main/java/com/followMe/order_server/order/presentation/OrderInternalController.java
@@ -2,12 +2,16 @@ package com.followMe.order_server.order.presentation;
 
 import com.followMe.common.response.ApiResponse;
 import com.followMe.order_server.order.application.OrderService;
+import com.followMe.order_server.order.application.dto.request.OrderUpdateStateRequest;
 import com.followMe.order_server.order.application.dto.response.OrderResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,5 +26,18 @@ public class OrderInternalController {
   public ResponseEntity<ApiResponse> readById(@PathVariable UUID orderId) {
     OrderResponse response = orderService.readById(orderId);
     return ApiResponse.ok(response);
+  }
+
+  @PatchMapping("/{orderId}/status")
+  public ResponseEntity<ApiResponse> updateStatus(
+      @PathVariable UUID orderId, @RequestBody OrderUpdateStateRequest updateStateRequest) {
+    orderService.updateStatus(orderId, updateStateRequest);
+    return ApiResponse.ok();
+  }
+
+  @DeleteMapping("/{orderId}")
+  public ResponseEntity<ApiResponse> delete(@PathVariable UUID orderId) {
+    orderService.softDeleteById(orderId);
+    return ApiResponse.ok();
   }
 }


### PR DESCRIPTION
### 📌 관련 이슈
- close #5 
- #9 이후 주문 재고 수정에 대한 검증 로직이 추가 예정.
- 배송 담당자 변경 내부 API는 #11 및 4/1 오전 스크럼 이후 진행 예정
- 각 수정 및 삭제에 대한 인가 로직은 인증/인가 서버 구현 이후 추가 예정
 
### 💡 작업 내용

- 주문 수정
- 주문 삭제 
- 상태 변경

### 🔍 변경 이유

### 📝 리뷰 포인트 (선택)

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)