### PR TITLE
[FEAT] 배송 담당자 관리 기능 구현

### DIFF
--- a/src/main/java/com/followMe/order_server/order/application/OrderSearchFilter.java
+++ b/src/main/java/com/followMe/order_server/order/application/OrderSearchFilter.java
@@ -18,6 +18,7 @@ public class OrderSearchFilter {
             null,
             condition.productId(),
             condition.orderId(),
+            condition.deliveryManagerId(),
             condition.productName(),
             condition.startDateTime(),
             condition.endDateTime(),
@@ -25,12 +26,26 @@ public class OrderSearchFilter {
             vendorId,
             condition.status());
       }
-      case DELIVERY_MANAGER -> condition;
+      case DELIVERY_MANAGER -> {
+        UUID deliveryManagerId = userContext.userId();
+        yield new OrderSearchCondition(
+            condition.hubId(),
+            condition.productId(),
+            condition.orderId(),
+            deliveryManagerId,
+            condition.productName(),
+            condition.startDateTime(),
+            condition.endDateTime(),
+            condition.createdBy(),
+            condition.vendorId(),
+            condition.status());
+      }
       case HUB_MANAGER ->
           new OrderSearchCondition(
               userContext.hubId(),
               condition.productId(),
               condition.orderId(),
+              condition.deliveryManagerId(),
               condition.productName(),
               condition.startDateTime(),
               condition.endDateTime(),

--- a/src/main/java/com/followMe/order_server/order/application/OrderService.java
+++ b/src/main/java/com/followMe/order_server/order/application/OrderService.java
@@ -4,6 +4,7 @@ import com.followMe.common.pagination.CursorRequest;
 import com.followMe.common.pagination.CursorResponse;
 import com.followMe.order_server.order.application.dto.request.OrderCreateRequest;
 import com.followMe.order_server.order.application.dto.request.OrderSearchCondition;
+import com.followMe.order_server.order.application.dto.request.OrderUpdateDeliveryManagerRequest;
 import com.followMe.order_server.order.application.dto.request.OrderUpdateRequest;
 import com.followMe.order_server.order.application.dto.request.OrderUpdateStateRequest;
 import com.followMe.order_server.order.application.dto.request.UserContext;
@@ -23,4 +24,7 @@ public interface OrderService {
   void updateStatus(UUID orderId, OrderUpdateStateRequest updateStateRequest);
 
   void softDeleteById(UUID orderId);
+
+  void updateDeliveryManager(
+      UUID orderId, OrderUpdateDeliveryManagerRequest updateDeliveryManagerRequest);
 }

--- a/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
+++ b/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
@@ -120,4 +120,12 @@ public class OrderServiceImpl implements OrderService {
     Order order = orderRepository.findById(orderId);
     order.softDelete(orderId);
   }
+
+  @Override
+  @Transactional
+  public void updateDeliveryManager(
+      UUID orderId, OrderUpdateDeliveryManagerRequest updateDeliveryManagerRequest) {
+    Order order = orderRepository.findById(orderId);
+    order.updateDeliveryManager(updateDeliveryManagerRequest.deliveryManagerId());
+  }
 }

--- a/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
+++ b/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
@@ -4,6 +4,7 @@ import com.followMe.common.pagination.CursorRequest;
 import com.followMe.common.pagination.CursorResponse;
 import com.followMe.order_server.order.application.dto.request.OrderCreateRequest;
 import com.followMe.order_server.order.application.dto.request.OrderSearchCondition;
+import com.followMe.order_server.order.application.dto.request.OrderUpdateDeliveryManagerRequest;
 import com.followMe.order_server.order.application.dto.request.OrderUpdateRequest;
 import com.followMe.order_server.order.application.dto.request.OrderUpdateStateRequest;
 import com.followMe.order_server.order.application.dto.request.UserContext;
@@ -14,6 +15,7 @@ import com.followMe.order_server.order.domain.ProductInfo;
 import com.followMe.order_server.order.domain.VendorInfo;
 import com.followMe.order_server.order.domain.repository.OrderRepository;
 import com.followMe.order_server.order.infrastructure.client.delivery.DeliveryClientAdapter;
+import com.followMe.order_server.order.infrastructure.client.delivery.dto.response.DeliveryCreateResponse;
 import com.followMe.order_server.order.infrastructure.client.hub.HubClient;
 import java.util.List;
 import java.util.UUID;
@@ -48,11 +50,14 @@ public class OrderServiceImpl implements OrderService {
 
     //    hubClient.getStockBySomething(); // TODO : 재고 확인에 따른 배송 가능 여부 파악
     UUID orderId = UUID.randomUUID();
+    DeliveryCreateResponse deliveryCreateResponse =
+        deliveryClientAdapter.createDelivery(
+            orderId, requestVendor.getHubId(), receiverVendor.getVendorId());
     Order order =
         Order.ofCreate(
             orderId,
-            deliveryClientAdapter.createDelivery(
-                orderId, request.requestVendorId(), request.receiverVendorId()),
+            deliveryCreateResponse.deliveryId(),
+            deliveryCreateResponse.deliveryManagerId(),
             productInfo,
             requestVendor,
             receiverVendor,

--- a/src/main/java/com/followMe/order_server/order/application/dto/request/OrderSearchCondition.java
+++ b/src/main/java/com/followMe/order_server/order/application/dto/request/OrderSearchCondition.java
@@ -8,6 +8,7 @@ public record OrderSearchCondition(
     UUID hubId,
     UUID productId,
     UUID orderId,
+    UUID deliveryManagerId,
     String productName,
     LocalDateTime startDateTime,
     LocalDateTime endDateTime,

--- a/src/main/java/com/followMe/order_server/order/application/dto/request/OrderUpdateDeliveryManagerRequest.java
+++ b/src/main/java/com/followMe/order_server/order/application/dto/request/OrderUpdateDeliveryManagerRequest.java
@@ -1,0 +1,5 @@
+package com.followMe.order_server.order.application.dto.request;
+
+import java.util.UUID;
+
+public record OrderUpdateDeliveryManagerRequest(UUID deliveryManagerId) {}

--- a/src/main/java/com/followMe/order_server/order/domain/Order.java
+++ b/src/main/java/com/followMe/order_server/order/domain/Order.java
@@ -29,6 +29,9 @@ public class Order extends BaseAudit2 {
   @Column(name = "delivery_id")
   private UUID deliveryId;
 
+  @Column(name = "current_delivery_manager_id")
+  private UUID currentDeliveryManagerId;
+
   @Embedded private ProductInfo productInfo;
 
   @Embedded
@@ -64,6 +67,7 @@ public class Order extends BaseAudit2 {
   private Order(
       UUID orderId,
       UUID deliveryId,
+      UUID currentDeliveryManagerId,
       ProductInfo productInfo,
       VendorInfo requestVendor,
       VendorInfo receiverVendor,
@@ -72,6 +76,7 @@ public class Order extends BaseAudit2 {
 
     this.orderId = orderId;
     this.deliveryId = deliveryId;
+    this.currentDeliveryManagerId = currentDeliveryManagerId;
     this.productInfo = productInfo;
     this.requestVendor = requestVendor;
     this.receiverVendor = receiverVendor;
@@ -82,6 +87,7 @@ public class Order extends BaseAudit2 {
   public static Order ofCreate(
       UUID orderId,
       UUID deliveryId,
+      UUID currentDeliveryManagerId,
       ProductInfo productInfo,
       VendorInfo requestVendor,
       VendorInfo receiverVendor,
@@ -90,6 +96,7 @@ public class Order extends BaseAudit2 {
     return Order.builder()
         .orderId(orderId)
         .deliveryId(deliveryId)
+        .currentDeliveryManagerId(currentDeliveryManagerId)
         .productInfo(productInfo)
         .requestVendor(requestVendor)
         .receiverVendor(receiverVendor)
@@ -118,5 +125,9 @@ public class Order extends BaseAudit2 {
 
   public void updateState(OrderState status) {
     this.status = status;
+  }
+
+  public void updateDeliveryManager(UUID updatedDeliveryManagerId) {
+    this.currentDeliveryManagerId = updatedDeliveryManagerId;
   }
 }

--- a/src/main/java/com/followMe/order_server/order/infrastructure/client/delivery/DeliveryClientAdapter.java
+++ b/src/main/java/com/followMe/order_server/order/infrastructure/client/delivery/DeliveryClientAdapter.java
@@ -1,6 +1,7 @@
 package com.followMe.order_server.order.infrastructure.client.delivery;
 
 import com.followMe.order_server.order.infrastructure.client.delivery.dto.request.DeliveryCreateRequest;
+import com.followMe.order_server.order.infrastructure.client.delivery.dto.response.DeliveryCreateResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -11,8 +12,10 @@ public class DeliveryClientAdapter {
 
   private final DeliveryFeignClient deliveryFeignClient;
 
-  public UUID createDelivery(UUID orderId, UUID sourceHubId, UUID vendorId) {
-    DeliveryCreateRequest createRequest = DeliveryCreateRequest.of(orderId, sourceHubId, vendorId);
-    return deliveryFeignClient.createDelivery(createRequest).deliveryId();
+  public DeliveryCreateResponse createDelivery(
+      UUID orderId, UUID sourceHubId, UUID receiverVendorId) {
+    DeliveryCreateRequest createRequest =
+        DeliveryCreateRequest.of(orderId, sourceHubId, receiverVendorId);
+    return deliveryFeignClient.createDelivery(createRequest);
   }
 }

--- a/src/main/java/com/followMe/order_server/order/infrastructure/client/delivery/dto/response/DeliveryCreateResponse.java
+++ b/src/main/java/com/followMe/order_server/order/infrastructure/client/delivery/dto/response/DeliveryCreateResponse.java
@@ -2,4 +2,4 @@ package com.followMe.order_server.order.infrastructure.client.delivery.dto.respo
 
 import java.util.UUID;
 
-public record DeliveryCreateResponse(UUID deliveryId) {}
+public record DeliveryCreateResponse(UUID deliveryId, UUID deliveryManagerId) {}

--- a/src/main/java/com/followMe/order_server/order/infrastructure/client/repository/OrderRepositoryAdapter.java
+++ b/src/main/java/com/followMe/order_server/order/infrastructure/client/repository/OrderRepositoryAdapter.java
@@ -40,6 +40,7 @@ public class OrderRepositoryAdapter implements OrderRepository {
         .selectFrom(order)
         .where(
             hubEq(condition.hubId()),
+            deliveryManagerEa(condition.deliveryManagerId()),
             productIdEq(condition.productId()),
             orderIdEq(condition.orderId()),
             productNameContains(condition.productName()),
@@ -59,6 +60,11 @@ public class OrderRepositoryAdapter implements OrderRepository {
     QOrder order = QOrder.order;
     return order.requestVendor.hubId.eq(hubId).or(order.receiverVendor.hubId.eq(hubId));
   }
+
+    private BooleanExpression deliveryManagerEa(UUID deliveryManagerId){
+      if(deliveryManagerId == null) return null;
+      return QOrder.order.currentDeliveryManagerId.eq(deliveryManagerId);
+    }
 
   private BooleanExpression productIdEq(UUID productId) {
     if (productId == null) return null;

--- a/src/main/java/com/followMe/order_server/order/infrastructure/client/repository/OrderRepositoryAdapter.java
+++ b/src/main/java/com/followMe/order_server/order/infrastructure/client/repository/OrderRepositoryAdapter.java
@@ -61,10 +61,10 @@ public class OrderRepositoryAdapter implements OrderRepository {
     return order.requestVendor.hubId.eq(hubId).or(order.receiverVendor.hubId.eq(hubId));
   }
 
-    private BooleanExpression deliveryManagerEa(UUID deliveryManagerId){
-      if(deliveryManagerId == null) return null;
-      return QOrder.order.currentDeliveryManagerId.eq(deliveryManagerId);
-    }
+  private BooleanExpression deliveryManagerEa(UUID deliveryManagerId) {
+    if (deliveryManagerId == null) return null;
+    return QOrder.order.currentDeliveryManagerId.eq(deliveryManagerId);
+  }
 
   private BooleanExpression productIdEq(UUID productId) {
     if (productId == null) return null;

--- a/src/main/java/com/followMe/order_server/order/presentation/OrderInternalController.java
+++ b/src/main/java/com/followMe/order_server/order/presentation/OrderInternalController.java
@@ -2,6 +2,7 @@ package com.followMe.order_server.order.presentation;
 
 import com.followMe.common.response.ApiResponse;
 import com.followMe.order_server.order.application.OrderService;
+import com.followMe.order_server.order.application.dto.request.OrderUpdateDeliveryManagerRequest;
 import com.followMe.order_server.order.application.dto.request.OrderUpdateStateRequest;
 import com.followMe.order_server.order.application.dto.response.OrderResponse;
 import java.util.UUID;
@@ -38,6 +39,14 @@ public class OrderInternalController {
   @DeleteMapping("/{orderId}")
   public ResponseEntity<ApiResponse> delete(@PathVariable UUID orderId) {
     orderService.softDeleteById(orderId);
+    return ApiResponse.ok();
+  }
+
+  @PatchMapping("/{orderId}/delivery")
+  public ResponseEntity<ApiResponse> updateDeliveryManager(
+      @PathVariable UUID orderId,
+      @RequestBody OrderUpdateDeliveryManagerRequest updateDeliveryManagerRequest) {
+    orderService.updateDeliveryManager(orderId, updateDeliveryManagerRequest);
     return ApiResponse.ok();
   }
 }


### PR DESCRIPTION
### 📌 관련 이슈
- close #11 

### 💡 작업 내용
- 주문 도메인의 배송 담당자에 대한 필드 추가

### 🔍 변경 이유


### 📝 리뷰 포인트 (선택)
- 배송 생성 요청에 대한 응답 DTO 필드 변경
- 주문의 현재 배송 담당자를 변경하는 내부 서버 API 구현 

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)