### PR TITLE
[FEAT] 예외 및 유효성 검사 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	implementation 'com.followMe:common-lib:1.0.2'
+	implementation 'com.followMe:common-lib:1.0.4'
 
 	implementation "io.github.openfeign.querydsl:querydsl-core:7.1"
 	implementation "io.github.openfeign.querydsl:querydsl-jpa:7.1"

--- a/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
+++ b/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
@@ -13,6 +13,7 @@ import com.followMe.order_server.order.domain.Order;
 import com.followMe.order_server.order.domain.OrderState;
 import com.followMe.order_server.order.domain.ProductInfo;
 import com.followMe.order_server.order.domain.VendorInfo;
+import com.followMe.order_server.order.domain.exception.StockShortageException;
 import com.followMe.order_server.order.domain.repository.OrderRepository;
 import com.followMe.order_server.order.infrastructure.client.delivery.DeliveryClientAdapter;
 import com.followMe.order_server.order.infrastructure.client.delivery.dto.response.DeliveryCreateResponse;
@@ -53,7 +54,7 @@ public class OrderServiceImpl implements OrderService {
     if (!hubClientAdapter
         .decreaseStockIfAvailable(orderId, productInfo.getProductId(), productInfo.getQuantity())
         .success()) {
-      throw new RuntimeException("재고 부족");
+      throw new StockShortageException();
     }
     ;
 

--- a/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
+++ b/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
@@ -139,6 +139,7 @@ public class OrderServiceImpl implements OrderService {
   }
 
   @Override
+  @Transactional
   public void cancel(UUID orderId, UUID userId) {
     Order order = orderRepository.findById(orderId);
     order.cancel(userId);

--- a/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
+++ b/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
@@ -56,7 +56,6 @@ public class OrderServiceImpl implements OrderService {
         .success()) {
       throw new StockShortageException();
     }
-    ;
 
     DeliveryCreateResponse deliveryCreateResponse =
         deliveryClientAdapter.createDelivery(

--- a/src/main/java/com/followMe/order_server/order/domain/Order.java
+++ b/src/main/java/com/followMe/order_server/order/domain/Order.java
@@ -1,8 +1,8 @@
 package com.followMe.order_server.order.domain;
 
-import com.followMe.order_server.order.domain.exception.OrderStateTransitionNotAllowedException;
 import com.followMe.order_server.order.domain.exception.InvalidOrderQuantityException;
 import com.followMe.order_server.order.domain.exception.InvalidStatusToCancelException;
+import com.followMe.order_server.order.domain.exception.OrderStateTransitionNotAllowedException;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
@@ -111,12 +111,16 @@ public class Order extends BaseAudit2 {
   }
 
   public void cancel(UUID userId) {
-    if (!isCancelable(this.status)) {
-      throw new InvalidStatusToCancelException();
-    }
+    validateStatusCancelAllowed(this.status);
     this.status = OrderState.CANCELLED;
     this.cancelledAt = LocalDateTime.now();
     this.cancelledBy = userId;
+  }
+
+  private void validateStatusCancelAllowed(OrderState status) {
+    if (!isCancelable(status)) {
+      throw new InvalidStatusToCancelException();
+    }
   }
 
   private boolean isCancelable(OrderState status) {
@@ -135,16 +139,24 @@ public class Order extends BaseAudit2 {
   }
 
   private void validateQuantity(int quantity) {
-    if (quantity <= 0) {
+    if (!isPositive(quantity)) {
       throw new InvalidOrderQuantityException();
     }
   }
 
+  private static boolean isPositive(int quantity) {
+    return quantity < 0;
+  }
+
   public void updateState(OrderState updatedStatus) {
+    validateStatusTransitionAllowed(updatedStatus);
+    this.status = updatedStatus;
+  }
+
+  private void validateStatusTransitionAllowed(OrderState updatedStatus) {
     if (!this.status.canTransitionTo(updatedStatus)) {
       throw new OrderStateTransitionNotAllowedException();
     }
-    this.status = updatedStatus;
   }
 
   public void updateDeliveryManager(UUID updatedDeliveryManagerId) {

--- a/src/main/java/com/followMe/order_server/order/domain/Order.java
+++ b/src/main/java/com/followMe/order_server/order/domain/Order.java
@@ -1,5 +1,8 @@
 package com.followMe.order_server.order.domain;
 
+import com.followMe.order_server.order.domain.exception.OrderStateTransitionNotAllowedException;
+import com.followMe.order_server.order.domain.exception.InvalidOrderQuantityException;
+import com.followMe.order_server.order.domain.exception.InvalidStatusToCancelException;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
@@ -15,11 +18,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "p_order")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
 public class Order extends BaseAudit2 {
 
   @Id
@@ -106,9 +111,16 @@ public class Order extends BaseAudit2 {
   }
 
   public void cancel(UUID userId) {
+    if (!isCancelable(this.status)) {
+      throw new InvalidStatusToCancelException();
+    }
     this.status = OrderState.CANCELLED;
     this.cancelledAt = LocalDateTime.now();
     this.cancelledBy = userId;
+  }
+
+  private boolean isCancelable(OrderState status) {
+    return status == OrderState.CREATED;
   }
 
   public void updateRequestNote(String requestNote) {
@@ -116,13 +128,23 @@ public class Order extends BaseAudit2 {
   }
 
   public void updateQuantity(int quantity) {
+    validateQuantity(quantity);
     this.productInfo =
         new ProductInfo(
             this.productInfo.getProductId(), this.productInfo.getProductName(), quantity);
   }
 
-  public void updateState(OrderState status) {
-    this.status = status;
+  private void validateQuantity(int quantity) {
+    if (quantity <= 0) {
+      throw new InvalidOrderQuantityException();
+    }
+  }
+
+  public void updateState(OrderState updatedStatus) {
+    if (!this.status.canTransitionTo(updatedStatus)) {
+      throw new OrderStateTransitionNotAllowedException();
+    }
+    this.status = updatedStatus;
   }
 
   public void updateDeliveryManager(UUID updatedDeliveryManagerId) {

--- a/src/main/java/com/followMe/order_server/order/domain/OrderState.java
+++ b/src/main/java/com/followMe/order_server/order/domain/OrderState.java
@@ -3,5 +3,12 @@ package com.followMe.order_server.order.domain;
 public enum OrderState {
   CREATED,
   COMPLETED,
-  CANCELLED
+  CANCELLED;
+
+  public boolean canTransitionTo(OrderState target) {
+    return switch (this) {
+      case CREATED -> target == COMPLETED || target == CANCELLED;
+      case COMPLETED, CANCELLED -> false;
+    };
+  }
 }

--- a/src/main/java/com/followMe/order_server/order/domain/exception/DeliveryClientUnavailableException.java
+++ b/src/main/java/com/followMe/order_server/order/domain/exception/DeliveryClientUnavailableException.java
@@ -5,6 +5,6 @@ import com.followMe.common.exception.BusinessException;
 public class DeliveryClientUnavailableException extends BusinessException {
 
   public DeliveryClientUnavailableException() {
-    super(OrderErrorCode.DELIVERY_CLIENT_UNAVAILABLE);
+    super(OrderErrorCode.DELIVERY_SERVICE_UNAVAILABLE);
   }
 }

--- a/src/main/java/com/followMe/order_server/order/domain/exception/HubClientUnavailableException.java
+++ b/src/main/java/com/followMe/order_server/order/domain/exception/HubClientUnavailableException.java
@@ -1,0 +1,9 @@
+package com.followMe.order_server.order.domain.exception;
+
+import com.followMe.common.exception.BusinessException;
+
+public class HubClientUnavailableException extends BusinessException {
+  public HubClientUnavailableException() {
+    super(OrderErrorCode.HUB_SERVICE_UNAVAILABLE);
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/domain/exception/InvalidOrderQuantityException.java
+++ b/src/main/java/com/followMe/order_server/order/domain/exception/InvalidOrderQuantityException.java
@@ -1,0 +1,9 @@
+package com.followMe.order_server.order.domain.exception;
+
+import com.followMe.common.exception.BusinessException;
+
+public class InvalidOrderQuantityException extends BusinessException {
+  public InvalidOrderQuantityException() {
+    super(OrderErrorCode.INVALID_ORDER_QUANTITY);
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/domain/exception/InvalidStatusToCancelException.java
+++ b/src/main/java/com/followMe/order_server/order/domain/exception/InvalidStatusToCancelException.java
@@ -1,0 +1,9 @@
+package com.followMe.order_server.order.domain.exception;
+
+import com.followMe.common.exception.BusinessException;
+
+public class InvalidStatusToCancelException extends BusinessException {
+  public InvalidStatusToCancelException() {
+    super(OrderErrorCode.ORDER_CANCELLATION_NOT_ALLOWED);
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/domain/exception/OrderErrorCode.java
+++ b/src/main/java/com/followMe/order_server/order/domain/exception/OrderErrorCode.java
@@ -8,9 +8,28 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum OrderErrorCode implements ErrorCode {
-  DELIVERY_NOT_FOUND("D001", "배달을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-  DELIVERY_CLIENT_UNAVAILABLE("D002", "배달 서비스를 일시적으로 사용할 수 없습니다.", HttpStatus.SERVICE_UNAVAILABLE),
-  ORDER_NOT_FOUND("O001", "해당 ID의 주문을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
+  // ===================== ORDER =====================
+  ORDER_NOT_FOUND("O001", "주문을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+  INVALID_ORDER_QUANTITY("O002", "주문 수량은 1 이상이어야 합니다.", HttpStatus.BAD_REQUEST),
+
+  ORDER_STATE_TRANSITION_NOT_ALLOWED("O003", "해당 상태로 변경할 수 없습니다.", HttpStatus.CONFLICT),
+
+  ORDER_CANCELLATION_NOT_ALLOWED("O004", "현재 상태에서는 주문을 취소할 수 없습니다.", HttpStatus.CONFLICT),
+
+  // ===================== PRODUCT =====================
+  PRODUCT_NOT_FOUND("P001", "상품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+  STOCK_SHORTAGE("P002", "재고가 부족합니다.", HttpStatus.CONFLICT),
+
+  // ===================== DELIVERY =====================
+  DELIVERY_NOT_FOUND("D001", "배달 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+  DELIVERY_SERVICE_UNAVAILABLE("D002", "배달 서비스를 사용할 수 없습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+
+  // ===================== HUB =====================
+  HUB_SERVICE_UNAVAILABLE("H001", "허브 서비스를 사용할 수 없습니다.", HttpStatus.SERVICE_UNAVAILABLE);
 
   private final String code;
   private final String message;

--- a/src/main/java/com/followMe/order_server/order/domain/exception/OrderStateTransitionNotAllowedException.java
+++ b/src/main/java/com/followMe/order_server/order/domain/exception/OrderStateTransitionNotAllowedException.java
@@ -1,0 +1,9 @@
+package com.followMe.order_server.order.domain.exception;
+
+import com.followMe.common.exception.BusinessException;
+
+public class OrderStateTransitionNotAllowedException extends BusinessException {
+  public OrderStateTransitionNotAllowedException() {
+    super(OrderErrorCode.ORDER_STATE_TRANSITION_NOT_ALLOWED);
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/domain/exception/ProductNotFoundException.java
+++ b/src/main/java/com/followMe/order_server/order/domain/exception/ProductNotFoundException.java
@@ -1,0 +1,9 @@
+package com.followMe.order_server.order.domain.exception;
+
+import com.followMe.common.exception.BusinessException;
+
+public class ProductNotFoundException extends BusinessException {
+  public ProductNotFoundException() {
+    super(OrderErrorCode.PRODUCT_NOT_FOUND);
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/domain/exception/StockShortageException.java
+++ b/src/main/java/com/followMe/order_server/order/domain/exception/StockShortageException.java
@@ -1,0 +1,9 @@
+package com.followMe.order_server.order.domain.exception;
+
+import com.followMe.common.exception.BusinessException;
+
+public class StockShortageException extends BusinessException {
+  public StockShortageException() {
+    super(OrderErrorCode.STOCK_SHORTAGE);
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/infrastructure/client/hub/HubFeignClientFallbackFactory.java
+++ b/src/main/java/com/followMe/order_server/order/infrastructure/client/hub/HubFeignClientFallbackFactory.java
@@ -1,10 +1,33 @@
 package com.followMe.order_server.order.infrastructure.client.hub;
 
+import com.followMe.order_server.order.domain.exception.HubClientUnavailableException;
+import com.followMe.order_server.order.domain.exception.ProductNotFoundException;
+import com.followMe.order_server.order.infrastructure.client.hub.dto.request.HubStockDecreaseRequest;
+import com.followMe.order_server.order.infrastructure.client.hub.dto.request.HubStockRollbackRequest;
+import com.followMe.order_server.order.infrastructure.client.hub.dto.response.HubStockDecreaseResponse;
+import com.followMe.order_server.order.infrastructure.client.hub.dto.response.HubStockRollbackResponse;
+import feign.FeignException;
 import org.springframework.cloud.openfeign.FallbackFactory;
 
 public class HubFeignClientFallbackFactory implements FallbackFactory<HubFeignClient> {
+
   @Override
   public HubFeignClient create(Throwable cause) {
-    throw new RuntimeException("허브 서버 API 연결 불가");
+
+    return new HubFeignClient() {
+
+      @Override
+      public HubStockDecreaseResponse decreaseStockIfAvailable(HubStockDecreaseRequest request) {
+        if (cause instanceof FeignException.NotFound) {
+          throw new ProductNotFoundException();
+        }
+        throw new HubClientUnavailableException();
+      }
+
+      @Override
+      public HubStockRollbackResponse rollbackStock(HubStockRollbackRequest request) {
+        throw new HubClientUnavailableException();
+      }
+    };
   }
 }


### PR DESCRIPTION
### 📌 관련 이슈
- close #19 
- 
### 💡 작업 내용
예외 작성
- 허브 서버 사용 불가
- 취소할 수 없는 주문 상태
- 잘못된 주문 상태 변경
- 잘못된 주문 수량 입력
- 배송 서버 사용 불가
- 상품 조회 불가
- 상품 재고 부족
- 각 예외에 맞는 ErrorCode 작성

도메인 검사 로직
- 상태 전파 제한
- 조회 시 soft-delete 되지 않은 주문에 대한 SQL 추가
- 주문 수량 검증
- 취소가능한 상태 제한

### 🔍 변경 이유
- 예외 작성 및 유효성 검사

### 📝 리뷰 포인트 (선택)


### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)