### PR TITLE
[FEAT] 상품 생성 후 배송 담당자에게 알람메세지 전송

### DIFF
--- a/docs/order.http
+++ b/docs/order.http
@@ -16,12 +16,17 @@ X-Vendor-Id: {{vendorId}}
 {
   "productId": "aaaaaaaa-0000-0000-0000-000000000001",
   "productName": "축구공",
+
   "requestVendorId": "bbbbbbbb-0000-0000-0000-000000000001",
   "requestVendorName": "요청업체A",
   "requestVendorHubId": "dddddddd-0000-0000-0000-000000000001",
+  "requestVendorHubName": "요청허브A",
+
   "receiverVendorId": "cccccccc-0000-0000-0000-000000000001",
   "receiverVendorName": "수령업체B",
   "receiverVendorHubId": "eeeeeeee-0000-0000-0000-000000000001",
+  "receiverVendorHubName": "수령허브B",
+
   "quantity": 10,
   "requestNote": "빠른 배송 부탁드립니다"
 }
@@ -49,3 +54,30 @@ X-User-Id: {{userId}}
 X-User-Role: MASTER
 X-Hub-Id: {{hubId}}
 X-Vendor-Id: {{vendorId}}
+
+### 주문 수정
+PATCH {{baseUrl}}/api/v1/orders/6a9ac0ef-7c43-4cb2-bec2-23fdf49ed3d9
+Content-Type: application/json
+X-User-Id: {{userId}}
+X-User-Role: MASTER
+X-Hub-Id: {{hubId}}
+X-Vendor-Id: {{vendorId}}
+
+{
+  "requestNote": "배송 메모 수정0405",
+  "quantity": 20
+}
+
+### SOFT - DELETE
+DELETE {{baseUrl}}/api/v1/orders/{{orderId}}
+X-User-Id: {{userId}}
+X-User-Role: MASTER
+X-Hub-Id: {{hubId}}
+X-Vendor-Id: {{vendorId}}
+
+### CANCEL
+PATCH {{baseUrl}}/api/v1/orders/{{orderId}}/cancel
+X-User-Id: {{userId}}
+X-User-Role: VENDOR
+X-Vendor-Id: {{vendorId}}
+X-Hub-Id: {{hubId}}

--- a/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
+++ b/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
@@ -18,6 +18,8 @@ import com.followMe.order_server.order.domain.repository.OrderRepository;
 import com.followMe.order_server.order.infrastructure.client.delivery.DeliveryClientAdapter;
 import com.followMe.order_server.order.infrastructure.client.delivery.dto.response.DeliveryCreateResponse;
 import com.followMe.order_server.order.infrastructure.client.hub.HubClientAdapter;
+import com.followMe.order_server.order.infrastructure.client.slack.MessageConstructor;
+import com.followMe.order_server.order.infrastructure.client.slack.SlackClientAdapter;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +33,7 @@ public class OrderServiceImpl implements OrderService {
   private final OrderRepository orderRepository;
   private final HubClientAdapter hubClientAdapter;
   private final DeliveryClientAdapter deliveryClientAdapter;
+  private final SlackClientAdapter slackClientAdapter;
 
   @Override
   @Transactional
@@ -41,13 +44,17 @@ public class OrderServiceImpl implements OrderService {
 
     VendorInfo requestVendor =
         new VendorInfo(
-            request.requestVendorId(), request.requestVendorName(), request.requestVendorHubId());
+            request.requestVendorId(),
+            request.requestVendorName(),
+            request.requestVendorHubId(),
+            request.requestVendorHubName());
 
     VendorInfo receiverVendor =
         new VendorInfo(
             request.receiverVendorId(),
             request.receiverVendorName(),
-            request.receiverVendorHubId());
+            request.receiverVendorHubId(),
+            request.receiverVendorHubName());
 
     UUID orderId = UUID.randomUUID();
 
@@ -71,6 +78,19 @@ public class OrderServiceImpl implements OrderService {
             request.requestNote());
 
     orderRepository.save(order);
+
+    sendSlack(order, deliveryCreateResponse);
+  }
+
+  private void sendSlack(Order order, DeliveryCreateResponse deliveryCreateResponse) {
+    String message =
+        MessageConstructor.generateOrderCreatedMessage(
+            order,
+            deliveryCreateResponse.waypoints(),
+            deliveryCreateResponse.receiverVendorAddress(),
+            deliveryCreateResponse.deliveryManagerName());
+
+    slackClientAdapter.sendSlack(order.getCurrentDeliveryManagerId(), order.getOrderId(), message);
   }
 
   @Override

--- a/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
+++ b/src/main/java/com/followMe/order_server/order/application/OrderServiceImpl.java
@@ -87,7 +87,6 @@ public class OrderServiceImpl implements OrderService {
         MessageConstructor.generateOrderCreatedMessage(
             order,
             deliveryCreateResponse.waypoints(),
-            deliveryCreateResponse.receiverVendorAddress(),
             deliveryCreateResponse.deliveryManagerName());
 
     slackClientAdapter.sendSlack(order.getCurrentDeliveryManagerId(), order.getOrderId(), message);

--- a/src/main/java/com/followMe/order_server/order/application/dto/request/OrderCreateRequest.java
+++ b/src/main/java/com/followMe/order_server/order/application/dto/request/OrderCreateRequest.java
@@ -8,8 +8,10 @@ public record OrderCreateRequest(
     UUID requestVendorId,
     String requestVendorName,
     UUID requestVendorHubId,
+    String requestVendorHubName,
     UUID receiverVendorId,
     String receiverVendorName,
     UUID receiverVendorHubId,
+    String receiverVendorHubName,
     int quantity,
     String requestNote) {}

--- a/src/main/java/com/followMe/order_server/order/domain/Order.java
+++ b/src/main/java/com/followMe/order_server/order/domain/Order.java
@@ -43,7 +43,8 @@ public class Order extends BaseAudit2 {
   @AttributeOverrides({
     @AttributeOverride(name = "vendorId", column = @Column(name = "request_vendor_id")),
     @AttributeOverride(name = "vendorName", column = @Column(name = "request_vendor_name")),
-    @AttributeOverride(name = "hubId", column = @Column(name = "request_vendor_hub_id"))
+    @AttributeOverride(name = "hubId", column = @Column(name = "request_vendor_hub_id")),
+    @AttributeOverride(name = "hubName", column = @Column(name = "request_vendor_hub_name"))
   })
   private VendorInfo requestVendor;
 
@@ -51,7 +52,8 @@ public class Order extends BaseAudit2 {
   @AttributeOverrides({
     @AttributeOverride(name = "vendorId", column = @Column(name = "receiver_vendor_id")),
     @AttributeOverride(name = "vendorName", column = @Column(name = "receiver_vendor_name")),
-    @AttributeOverride(name = "hubId", column = @Column(name = "receiver_vendor_hub_id"))
+    @AttributeOverride(name = "hubId", column = @Column(name = "receiver_vendor_hub_id")),
+    @AttributeOverride(name = "hubName", column = @Column(name = "receiver_vendor_hub_name"))
   })
   private VendorInfo receiverVendor;
 
@@ -110,6 +112,10 @@ public class Order extends BaseAudit2 {
         .build();
   }
 
+  private static boolean isPositive(int quantity) {
+    return quantity < 0;
+  }
+
   public void cancel(UUID userId) {
     validateStatusCancelAllowed(this.status);
     this.status = OrderState.CANCELLED;
@@ -142,10 +148,6 @@ public class Order extends BaseAudit2 {
     if (!isPositive(quantity)) {
       throw new InvalidOrderQuantityException();
     }
-  }
-
-  private static boolean isPositive(int quantity) {
-    return quantity < 0;
   }
 
   public void updateState(OrderState updatedStatus) {

--- a/src/main/java/com/followMe/order_server/order/domain/VendorInfo.java
+++ b/src/main/java/com/followMe/order_server/order/domain/VendorInfo.java
@@ -14,8 +14,9 @@ public class VendorInfo {
   private UUID vendorId;
   private String vendorName;
   private UUID hubId;
+  private String hubName;
 
-  public VendorInfo(UUID vendorId, String vendorName, UUID hubId) {
+  public VendorInfo(UUID vendorId, String vendorName, UUID hubId, String hubName) {
     if (vendorId == null) throw new IllegalArgumentException("vendorId 필수");
     if (vendorName == null || vendorName.isBlank())
       throw new IllegalArgumentException("vendorName 필수");
@@ -24,5 +25,6 @@ public class VendorInfo {
     this.vendorId = vendorId;
     this.vendorName = vendorName;
     this.hubId = hubId;
+    this.hubName = hubName;
   }
 }

--- a/src/main/java/com/followMe/order_server/order/domain/exception/OrderErrorCode.java
+++ b/src/main/java/com/followMe/order_server/order/domain/exception/OrderErrorCode.java
@@ -29,7 +29,10 @@ public enum OrderErrorCode implements ErrorCode {
   DELIVERY_SERVICE_UNAVAILABLE("D002", "배달 서비스를 사용할 수 없습니다.", HttpStatus.SERVICE_UNAVAILABLE),
 
   // ===================== HUB =====================
-  HUB_SERVICE_UNAVAILABLE("H001", "허브 서비스를 사용할 수 없습니다.", HttpStatus.SERVICE_UNAVAILABLE);
+  HUB_SERVICE_UNAVAILABLE("H001", "허브 서비스를 사용할 수 없습니다.", HttpStatus.SERVICE_UNAVAILABLE),
+
+  // ===================== SLACK =====================
+  SLACK_SEVER_NOT_AVAILABLE("S001", "슬랙 메세지 전송 서비스를 사용할 수 없습니다", HttpStatus.SERVICE_UNAVAILABLE);
 
   private final String code;
   private final String message;

--- a/src/main/java/com/followMe/order_server/order/domain/exception/SlackClientUnavailableException.java
+++ b/src/main/java/com/followMe/order_server/order/domain/exception/SlackClientUnavailableException.java
@@ -1,0 +1,9 @@
+package com.followMe.order_server.order.domain.exception;
+
+import com.followMe.common.exception.BusinessException;
+
+public class SlackClientUnavailableException extends BusinessException {
+  public SlackClientUnavailableException() {
+    super(OrderErrorCode.SLACK_SEVER_NOT_AVAILABLE);
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/infrastructure/client/delivery/DeliveryFeignClient.java
+++ b/src/main/java/com/followMe/order_server/order/infrastructure/client/delivery/DeliveryFeignClient.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@FeignClient(name = "delivery-service")
+@FeignClient(name = "delivery-server", fallbackFactory = DeliveryFeignClientFallbackFactory.class)
 public interface DeliveryFeignClient {
 
   @PostMapping("/internal/v1/deliveries")

--- a/src/main/java/com/followMe/order_server/order/infrastructure/client/delivery/dto/response/DeliveryCreateResponse.java
+++ b/src/main/java/com/followMe/order_server/order/infrastructure/client/delivery/dto/response/DeliveryCreateResponse.java
@@ -7,5 +7,4 @@ public record DeliveryCreateResponse(
     UUID deliveryId,
     UUID deliveryManagerId,
     List<String> waypoints,
-    String receiverVendorAddress,
     String deliveryManagerName) {}

--- a/src/main/java/com/followMe/order_server/order/infrastructure/client/delivery/dto/response/DeliveryCreateResponse.java
+++ b/src/main/java/com/followMe/order_server/order/infrastructure/client/delivery/dto/response/DeliveryCreateResponse.java
@@ -1,5 +1,11 @@
 package com.followMe.order_server.order.infrastructure.client.delivery.dto.response;
 
+import java.util.List;
 import java.util.UUID;
 
-public record DeliveryCreateResponse(UUID deliveryId, UUID deliveryManagerId) {}
+public record DeliveryCreateResponse(
+    UUID deliveryId,
+    UUID deliveryManagerId,
+    List<String> waypoints,
+    String receiverVendorAddress,
+    String deliveryManagerName) {}

--- a/src/main/java/com/followMe/order_server/order/infrastructure/client/delivery/dto/response/DeliveryCreateResponse.java
+++ b/src/main/java/com/followMe/order_server/order/infrastructure/client/delivery/dto/response/DeliveryCreateResponse.java
@@ -4,7 +4,4 @@ import java.util.List;
 import java.util.UUID;
 
 public record DeliveryCreateResponse(
-    UUID deliveryId,
-    UUID deliveryManagerId,
-    List<String> waypoints,
-    String deliveryManagerName) {}
+    UUID deliveryId, UUID deliveryManagerId, List<String> waypoints, String deliveryManagerName) {}

--- a/src/main/java/com/followMe/order_server/order/infrastructure/client/slack/MessageConstructor.java
+++ b/src/main/java/com/followMe/order_server/order/infrastructure/client/slack/MessageConstructor.java
@@ -12,7 +12,7 @@ public class MessageConstructor {
       DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
   public static String generateOrderCreatedMessage(
-      Order order, List<String> waypoints, String destinationAddress, String deliveryManagerName) {
+      Order order, List<String> waypoints, String deliveryManagerName) {
 
     StringBuilder waypointsContent = new StringBuilder();
     for (String waypoint : waypoints) {
@@ -46,7 +46,7 @@ public class MessageConstructor {
         order.getProductInfo().getProductName(),
         order.getRequestVendor().getHubName(),
         waypointsContent,
-        destinationAddress,
+        order.getReceiverVendor().getHubName(),
         deliveryManagerName,
         order.getRequestNote(),
         deadline);

--- a/src/main/java/com/followMe/order_server/order/infrastructure/client/slack/MessageConstructor.java
+++ b/src/main/java/com/followMe/order_server/order/infrastructure/client/slack/MessageConstructor.java
@@ -1,0 +1,54 @@
+package com.followMe.order_server.order.infrastructure.client.slack;
+
+import com.followMe.order_server.order.domain.Order;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public class MessageConstructor {
+
+  private static final DateTimeFormatter FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+  public static String generateOrderCreatedMessage(
+      Order order, List<String> waypoints, String destinationAddress, String deliveryManagerName) {
+
+    StringBuilder waypointsContent = new StringBuilder();
+    for (String waypoint : waypoints) {
+      waypointsContent.append(waypoint).append(", ");
+    }
+
+    LocalDateTime createdAt = order.getCreatedAt().atZone(ZoneId.systemDefault()).toLocalDateTime();
+
+    String deadline = createdAt.plusDays(2).format(FORMATTER);
+
+    return String.format(
+        """
+                주문번호 : %s
+                주문업체 : %s
+                주문 시간 : %s
+                주문 상품 : %s
+
+                발송지 : %s
+                경유지 : %s
+                도착지 : %s
+
+                배송담당자 : %s
+
+                요청사항 : %s
+
+                최종 발송 시한 : %s
+                """,
+        order.getOrderId(),
+        order.getReceiverVendor().getVendorName(),
+        order.getCreatedAt(),
+        order.getProductInfo().getProductName(),
+        order.getRequestVendor().getHubName(),
+        waypointsContent,
+        destinationAddress,
+        deliveryManagerName,
+        order.getRequestNote(),
+        deadline);
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/infrastructure/client/slack/SlackClientAdapter.java
+++ b/src/main/java/com/followMe/order_server/order/infrastructure/client/slack/SlackClientAdapter.java
@@ -1,0 +1,18 @@
+package com.followMe.order_server.order.infrastructure.client.slack;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SlackClientAdapter {
+
+  private final SlackFeignClient slackFeignClient;
+
+  public void sendSlack(UUID userId, UUID orderId, String message) {
+    SlackMessageSendRequest slackMessageSendRequest =
+        SlackMessageSendRequest.of(userId, orderId, message);
+    slackFeignClient.sendSlack(slackMessageSendRequest);
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/infrastructure/client/slack/SlackFeignClient.java
+++ b/src/main/java/com/followMe/order_server/order/infrastructure/client/slack/SlackFeignClient.java
@@ -1,0 +1,13 @@
+package com.followMe.order_server.order.infrastructure.client.slack;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@FeignClient(
+    name = "message-server",
+    fallbackFactory = SlackFeignClientFallbackFactory.class) // TODO is correct ?
+public interface SlackFeignClient {
+
+  @PostMapping("/internal/v1/slack/send")
+  void sendSlack(SlackMessageSendRequest slackMessageSendRequest);
+}

--- a/src/main/java/com/followMe/order_server/order/infrastructure/client/slack/SlackFeignClientFallbackFactory.java
+++ b/src/main/java/com/followMe/order_server/order/infrastructure/client/slack/SlackFeignClientFallbackFactory.java
@@ -1,0 +1,19 @@
+package com.followMe.order_server.order.infrastructure.client.slack;
+
+import com.followMe.order_server.order.domain.exception.SlackClientUnavailableException;
+import org.springframework.cloud.openfeign.FallbackFactory;
+
+public class SlackFeignClientFallbackFactory implements FallbackFactory<SlackFeignClient> {
+
+  @Override
+  public SlackFeignClient create(Throwable cause) {
+
+    return new SlackFeignClient() {
+
+      @Override
+      public void sendSlack(SlackMessageSendRequest slackMessageSendRequest) {
+        throw new SlackClientUnavailableException();
+      }
+    };
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/infrastructure/client/slack/SlackMessageSendRequest.java
+++ b/src/main/java/com/followMe/order_server/order/infrastructure/client/slack/SlackMessageSendRequest.java
@@ -1,0 +1,10 @@
+package com.followMe.order_server.order.infrastructure.client.slack;
+
+import java.util.UUID;
+
+public record SlackMessageSendRequest(
+    String messageType, UUID userId, String referenceType, UUID referenceId, String message) {
+  public static SlackMessageSendRequest of(UUID userId, UUID orderId, String message) {
+    return new SlackMessageSendRequest("ORDER", userId, "referenceType", orderId, message);
+  }
+}

--- a/src/main/java/com/followMe/order_server/order/presentation/OrderController.java
+++ b/src/main/java/com/followMe/order_server/order/presentation/OrderController.java
@@ -69,6 +69,7 @@ public class OrderController {
   @PatchMapping("/{orderId}")
   public ResponseEntity<ApiResponse> update(
       @PathVariable UUID orderId, @RequestBody OrderUpdateRequest updateRequest) {
+    // TODO: 인증인가 필요
     orderService.update(orderId, updateRequest);
     return ApiResponse.ok();
   }
@@ -82,6 +83,7 @@ public class OrderController {
 
   @DeleteMapping("/{orderId}")
   public ResponseEntity<ApiResponse> delete(@PathVariable UUID orderId) {
+    // TODO: 인증인가 필요
     orderService.softDeleteById(orderId);
     return ApiResponse.ok();
   }
@@ -89,6 +91,7 @@ public class OrderController {
   @PatchMapping("/{orderId}/cancel")
   public ResponseEntity<ApiResponse> cancel(
       @PathVariable UUID orderId, @ModelAttribute UserContext userContext) {
+    // TODO: 인증인가 필요
     orderService.cancel(orderId, userContext.userId());
     return ApiResponse.ok();
   }

--- a/src/main/java/com/followMe/order_server/order/presentation/OrderController.java
+++ b/src/main/java/com/followMe/order_server/order/presentation/OrderController.java
@@ -11,7 +11,6 @@ import com.followMe.order_server.order.application.dto.request.OrderUpdateStateR
 import com.followMe.order_server.order.application.dto.request.UserContext;
 import com.followMe.order_server.order.application.dto.request.UserRole;
 import com.followMe.order_server.order.application.dto.response.OrderResponse;
-import com.followMe.order_server.order.infrastructure.client.repository.OrderRepositoryAdapter;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -32,7 +31,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrderController {
 
   private final OrderService orderService;
-  private final OrderRepositoryAdapter orderRepositoryAdapter;
 
   @ModelAttribute
   public UserContext userContext(


### PR DESCRIPTION
### 📌 관련 이슈
- close #10 
- close #24 

### 💡 작업 내용
- slack 알람 서버 호출 Feign client 작성
- 배송 생성 요청에 대한 응답값 필드 변경 : 경유지에 대한 리스트, 배송 담당자 이름, 수령자 주소

### 🔍 변경 이유

### 📝 리뷰 포인트 (선택)

### 🧠 기타 참고 사항
(참고 문서, 스크린샷 등)